### PR TITLE
feat: add initial test project and BooksController unit tests

### DIFF
--- a/backend/BookService.Tests/BookService.Tests.csproj
+++ b/backend/BookService.Tests/BookService.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BookService\BookService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/BookService.Tests/UnitTest1.cs
+++ b/backend/BookService.Tests/UnitTest1.cs
@@ -1,0 +1,44 @@
+﻿using Xunit;
+using Microsoft.EntityFrameworkCore;
+using BookService.Data;
+using BookService.Repositories;
+using BookService.Services;
+using BookService.Controllers;
+using BookService.Models;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+using BookService.Dtos;
+
+namespace BookService.Tests
+{
+    public class BooksControllerTests
+    {
+        private BooksController GetControllerWithInMemoryDb()
+        {
+            var options = new DbContextOptionsBuilder<BookDbContext>()
+                .UseInMemoryDatabase(databaseName: "BookServiceTestDb")
+                .Options;
+
+            var dbContext = new BookDbContext(options);
+
+            var repo = new BookRepository(dbContext);
+            var service = new BookServiceImpl(repo);
+            return new BooksController(service);
+        }
+
+        [Fact]
+        public async Task GetAllBooks_ReturnsEmpty_WhenNoBooks()
+        {
+            // Arrange
+            var controller = GetControllerWithInMemoryDb();
+
+            // Act
+            var result = await controller.GetAll();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var books = Assert.IsType<List<BookDto>>(okResult.Value);
+            Assert.Empty(books);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new test project for the `BookService` backend, setting up the foundational structure for unit testing and adding an initial test for the `BooksController`. The main changes are the addition of the test project configuration and a basic test to verify the behavior of retrieving all books when the database is empty.

**Test project setup:**

* Added a new test project file `BookService.Tests.csproj` targeting .NET 9.0, including references to essential testing and ASP.NET Core packages, and linking to the main `BookService` project for integration.

**Initial controller test:**

* Created the `BooksControllerTests` class in `UnitTest1.cs` with a test that verifies `GetAll()` returns an empty list when there are no books in the in-memory database.