### PR TITLE
Test/book service unit

### DIFF
--- a/.github/workflows/book-pipline.yml
+++ b/.github/workflows/book-pipline.yml
@@ -38,8 +38,11 @@ jobs:
       - name: Build
         run: dotnet build ./backend/BookService/BookService.csproj --configuration Release --no-restore
 
+      - name: Create TestResults folder
+        run: mkdir -p ./backend/BookService.Tests/TestResults
+
       - name: Run Tests
-        run: dotnet test ./backend/BookService.Tests/BookService.Tests.csproj --no-build --logger:"junit;LogFilePath=backend/BookService.Tests/TestResults/TestResults.xml;AssemblyName=BookService.Tests"
+        run: dotnet test ./backend/BookService.Tests/BookService.Tests.csproj --no-build --logger "junit;LogFilePath=backend/BookService.Tests/TestResults/TestResults.xml;AssemblyName=BookService.Tests"
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4

--- a/backend/BookService.Tests/BookChunkTests.cs
+++ b/backend/BookService.Tests/BookChunkTests.cs
@@ -1,0 +1,286 @@
+using Xunit;
+using Microsoft.EntityFrameworkCore;
+using BookService.Data;
+using BookService.Repositories;
+using BookService.Models;
+
+namespace BookService.Tests
+{
+    public class BookChunkRepositoryTests : IDisposable
+    {
+        private readonly BookDbContext _context;
+        private readonly IBookChunkRepository _chunkRepository;
+
+        public BookChunkRepositoryTests()
+        {
+            var options = new DbContextOptionsBuilder<BookDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+
+            _context = new BookDbContext(options);
+            _chunkRepository = new BookChunkRepository(_context);
+        }
+
+        [Fact]
+        public async Task GetByBookIdAsync_ShouldReturnChunks_WhenChunksExist()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Test Book",
+                Description = "Test Description",
+                AuthorId = 1,
+                AuthorName = "Test Author",
+                TitleSlug = "test-book",
+                CoverImagePath = "/images/test.jpg",
+                Chunks = new List<BookChunk>
+                {
+                    new BookChunk { ChunkNumber = 1, StoragePath = "/chunks/chunk1.pdf" },
+                    new BookChunk { ChunkNumber = 2, StoragePath = "/chunks/chunk2.pdf" },
+                    new BookChunk { ChunkNumber = 3, StoragePath = "/chunks/chunk3.pdf" }
+                }
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _chunkRepository.GetByBookIdAsync(book.Id);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(3, result.Count());
+            Assert.Contains(result, c => c.ChunkNumber == 2 && c.StoragePath == "/chunks/chunk2.pdf");
+        }
+
+        [Fact]
+        public async Task GetByBookIdAsync_ShouldReturnEmptyCollection_WhenBookHasNoChunks()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Test Book",
+                Description = "Test Description",
+                AuthorId = 1,
+                AuthorName = "Test Author",
+                TitleSlug = "test-book",
+                CoverImagePath = "/images/test.jpg",
+                Chunks = new List<BookChunk>()
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _chunkRepository.GetByBookIdAsync(book.Id);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetByBookIdAsync_ShouldReturnEmptyCollection_WhenBookDoesNotExist()
+        {
+            // Act
+            var result = await _chunkRepository.GetByBookIdAsync(999);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_ShouldReturnChunk_WhenChunkExists()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Test Book",
+                Description = "Test Description",
+                AuthorId = 1,
+                AuthorName = "Test Author",
+                TitleSlug = "test-book",
+                CoverImagePath = "/images/test.jpg",
+                Chunks = new List<BookChunk>
+                {
+                    new BookChunk { ChunkNumber = 1, StoragePath = "/chunks/chunk1.pdf" }
+                }
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            var chunkId = book.Chunks.First().Id;
+
+            // Act
+            var result = await _chunkRepository.GetByIdAsync(chunkId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(chunkId, result.Id);
+            Assert.Equal(1, result.ChunkNumber);
+            Assert.Equal("/chunks/chunk1.pdf", result.StoragePath);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_ShouldReturnNull_WhenChunkDoesNotExist()
+        {
+            // Act
+            var result = await _chunkRepository.GetByIdAsync(999);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task AddAsync_ShouldAddChunkToBook()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Test Book",
+                Description = "Test Description",
+                AuthorId = 1,
+                AuthorName = "Test Author",
+                TitleSlug = "test-book",
+                CoverImagePath = "/images/test.jpg"
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            var chunk = new BookChunk
+            {
+                BookId = book.Id,
+                ChunkNumber = 1,
+                StoragePath = "/chunks/new-chunk.pdf"
+            };
+
+            // Act
+            var result = await _chunkRepository.AddAsync(chunk);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(result.Id > 0);
+            Assert.Equal(book.Id, result.BookId);
+            Assert.Equal(1, result.ChunkNumber);
+            Assert.Equal("/chunks/new-chunk.pdf", result.StoragePath);
+
+            // Verify it was saved to database
+            var savedChunk = await _context.BookChunks.FindAsync(result.Id);
+            Assert.NotNull(savedChunk);
+            Assert.Equal("/chunks/new-chunk.pdf", savedChunk.StoragePath);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_ShouldUpdateExistingChunk()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Test Book",
+                Description = "Test Description",
+                AuthorId = 1,
+                AuthorName = "Test Author",
+                TitleSlug = "test-book",
+                CoverImagePath = "/images/test.jpg",
+                Chunks = new List<BookChunk>
+                {
+                    new BookChunk { ChunkNumber = 1, StoragePath = "/chunks/original.pdf" }
+                }
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            var chunk = book.Chunks.First();
+            chunk.StoragePath = "/chunks/updated.pdf";
+
+            // Act
+            await _chunkRepository.UpdateAsync(chunk);
+
+            // Assert - Verify in database
+            var updatedChunk = await _context.BookChunks.FindAsync(chunk.Id);
+            Assert.NotNull(updatedChunk);
+            Assert.Equal("/chunks/updated.pdf", updatedChunk.StoragePath);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_ShouldDeleteChunk_WhenChunkExists()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Test Book",
+                Description = "Test Description",
+                AuthorId = 1,
+                AuthorName = "Test Author",
+                TitleSlug = "test-book",
+                CoverImagePath = "/images/test.jpg",
+                Chunks = new List<BookChunk>
+                {
+                    new BookChunk { ChunkNumber = 1, StoragePath = "/chunks/to-delete.pdf" }
+                }
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            var chunkId = book.Chunks.First().Id;
+
+            // Act
+            await _chunkRepository.DeleteAsync(chunkId);
+
+            // Assert - Verify chunk was deleted
+            var deletedChunk = await _context.BookChunks.FindAsync(chunkId);
+            Assert.Null(deletedChunk);
+        }
+
+        [Fact]
+        public async Task GetByBookIdAsync_ShouldReturnChunksOrderedByChunkNumber()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Test Book",
+                Description = "Test Description",
+                AuthorId = 1,
+                AuthorName = "Test Author",
+                TitleSlug = "test-book",
+                CoverImagePath = "/images/test.jpg",
+                Chunks = new List<BookChunk>
+                {
+                    new BookChunk { ChunkNumber = 3, StoragePath = "/chunks/chunk3.pdf" },
+                    new BookChunk { ChunkNumber = 1, StoragePath = "/chunks/chunk1.pdf" },
+                    new BookChunk { ChunkNumber = 2, StoragePath = "/chunks/chunk2.pdf" }
+                }
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _chunkRepository.GetByBookIdAsync(book.Id);
+            var chunks = result.ToList();
+
+            // Assert
+            Assert.Equal(3, chunks.Count);
+
+            // Verify chunks are ordered by ChunkNumber
+            Assert.Equal(1, chunks[0].ChunkNumber);
+            Assert.Equal(2, chunks[1].ChunkNumber);
+            Assert.Equal(3, chunks[2].ChunkNumber);
+
+            // Verify storage paths
+            Assert.Equal("/chunks/chunk1.pdf", chunks[0].StoragePath);
+            Assert.Equal("/chunks/chunk2.pdf", chunks[1].StoragePath);
+            Assert.Equal("/chunks/chunk3.pdf", chunks[2].StoragePath);
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+    }
+}

--- a/backend/BookService.Tests/BookRepositoryTests.cs
+++ b/backend/BookService.Tests/BookRepositoryTests.cs
@@ -1,0 +1,294 @@
+using Xunit;
+using Microsoft.EntityFrameworkCore;
+using BookService.Data;
+using BookService.Repositories;
+using BookService.Models;
+
+namespace BookService.Tests
+{
+    public class BookRepositoryTests : IDisposable
+    {
+        private readonly BookDbContext _context;
+        private readonly IBookRepository _bookRepository;
+
+        public BookRepositoryTests()
+        {
+            var options = new DbContextOptionsBuilder<BookDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+
+            _context = new BookDbContext(options);
+            _bookRepository = new BookRepository(_context);
+        }
+
+        [Fact]
+        public async Task AddAsync_ShouldAddBookToDatabase()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Test Book",
+                Description = "Test Description",
+                AuthorId = 1,
+                AuthorName = "Test Author",
+                TitleSlug = "test-book",
+                CoverImagePath = "/images/test.jpg"
+            };
+
+            // Act
+            var result = await _bookRepository.AddAsync(book);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(result.Id > 0);
+            Assert.Equal("Test Book", result.Title);
+
+            // Verify it was saved to the database
+            var savedBook = await _context.Books.FindAsync(result.Id);
+            Assert.NotNull(savedBook);
+            Assert.Equal("Test Book", savedBook.Title);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_ShouldReturnBook_WhenBookExists()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Test Book",
+                Description = "Test Description",
+                AuthorId = 1,
+                AuthorName = "Test Author",
+                TitleSlug = "test-book",
+                CoverImagePath = "/images/test.jpg",
+                Chunks = new List<BookChunk>
+                {
+                    new BookChunk { ChunkNumber = 1, StoragePath = "/chunks/chunk1.pdf" },
+                    new BookChunk { ChunkNumber = 2, StoragePath = "/chunks/chunk2.pdf" }
+                }
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _bookRepository.GetByIdAsync(book.Id);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(book.Id, result.Id);
+            Assert.Equal("Test Book", result.Title);
+            Assert.Equal(2, result.Chunks.Count);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_ShouldReturnNull_WhenBookDoesNotExist()
+        {
+            // Act
+            var result = await _bookRepository.GetByIdAsync(999);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task GetAllAsync_ShouldReturnEmptyList_WhenNoBooksExist()
+        {
+            // Act
+            var result = await _bookRepository.GetAllAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetAllAsync_ShouldReturnAllBooks_WhenBooksExist()
+        {
+            // Arrange
+            var book1 = new Book
+            {
+                Title = "Book 1",
+                Description = "Description 1",
+                AuthorId = 1,
+                AuthorName = "Author 1",
+                TitleSlug = "book-1",
+                CoverImagePath = "/images/book1.jpg"
+            };
+
+            var book2 = new Book
+            {
+                Title = "Book 2",
+                Description = "Description 2",
+                AuthorId = 2,
+                AuthorName = "Author 2",
+                TitleSlug = "book-2",
+                CoverImagePath = "/images/book2.jpg"
+            };
+
+            await _context.Books.AddRangeAsync(book1, book2);
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _bookRepository.GetAllAsync();
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.Contains(result, b => b.Title == "Book 1");
+            Assert.Contains(result, b => b.Title == "Book 2");
+        }
+
+        [Fact]
+        public async Task UpdateAsync_ShouldUpdateBook_WhenBookExists()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Original Title",
+                Description = "Original Description",
+                AuthorId = 1,
+                AuthorName = "Original Author",
+                TitleSlug = "original-title",
+                CoverImagePath = "/images/original.jpg"
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            // Modify the book
+            book.Title = "Updated Title";
+            book.Description = "Updated Description";
+            book.TitleSlug = "updated-title";
+
+            // Act
+            var result = await _bookRepository.UpdateAsync(book);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Updated Title", result.Title);
+            Assert.Equal("Updated Description", result.Description);
+            Assert.Equal("updated-title", result.TitleSlug);
+
+            // Verify in database
+            var updatedBook = await _context.Books.FindAsync(book.Id);
+            Assert.Equal("Updated Title", updatedBook!.Title);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_ShouldDeleteBook_WhenBookExists()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Book to Delete",
+                Description = "Description",
+                AuthorId = 1,
+                AuthorName = "Author",
+                TitleSlug = "book-to-delete",
+                CoverImagePath = "/images/delete.jpg"
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _bookRepository.DeleteAsync(book.Id);
+
+            // Assert
+            Assert.True(result);
+
+            // Verify book was deleted
+            var deletedBook = await _context.Books.FindAsync(book.Id);
+            Assert.Null(deletedBook);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_ShouldReturnFalse_WhenBookDoesNotExist()
+        {
+            // Act
+            var result = await _bookRepository.DeleteAsync(999);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task AddAsync_ShouldAddBookWithChunks()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Book with Chunks",
+                Description = "Description",
+                AuthorId = 1,
+                AuthorName = "Author",
+                TitleSlug = "book-with-chunks",
+                CoverImagePath = "/images/cover.jpg",
+                Chunks = new List<BookChunk>
+                {
+                    new BookChunk { ChunkNumber = 1, StoragePath = "/chunks/chunk1.pdf" },
+                    new BookChunk { ChunkNumber = 2, StoragePath = "/chunks/chunk2.pdf" },
+                    new BookChunk { ChunkNumber = 3, StoragePath = "/chunks/chunk3.pdf" }
+                }
+            };
+
+            // Act
+            var result = await _bookRepository.AddAsync(book);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(result.Id > 0);
+
+            // Verify chunks were saved
+            var savedBook = await _context.Books
+                .Include(b => b.Chunks)
+                .FirstOrDefaultAsync(b => b.Id == result.Id);
+
+            Assert.NotNull(savedBook);
+            Assert.Equal(3, savedBook.Chunks.Count);
+            Assert.All(savedBook.Chunks, chunk => Assert.True(chunk.BookId == savedBook.Id));
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_ShouldIncludeAllChunks()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Book with Chunks",
+                Description = "Description",
+                AuthorId = 1,
+                AuthorName = "Author",
+                TitleSlug = "book-with-chunks",
+                CoverImagePath = "/images/cover.jpg",
+                Chunks = new List<BookChunk>
+                {
+                    new BookChunk { ChunkNumber = 3, StoragePath = "/chunks/chunk3.pdf" },
+                    new BookChunk { ChunkNumber = 1, StoragePath = "/chunks/chunk1.pdf" },
+                    new BookChunk { ChunkNumber = 2, StoragePath = "/chunks/chunk2.pdf" }
+                }
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _bookRepository.GetByIdAsync(book.Id);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(3, result.Chunks.Count);
+
+            // Verify all chunk numbers are present
+            var chunkNumbers = result.Chunks.Select(c => c.ChunkNumber).ToList();
+            Assert.Contains(1, chunkNumbers);
+            Assert.Contains(2, chunkNumbers);
+            Assert.Contains(3, chunkNumbers);
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+    }
+}

--- a/backend/BookService.Tests/BookService.Tests.csproj
+++ b/backend/BookService.Tests/BookService.Tests.csproj
@@ -9,7 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
-      <PackageReference Include="JunitXml.TestLogger" Version="6.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="JunitXml.TestLogger" Version="6.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.9" />

--- a/backend/BookService.Tests/BooksControllerTests.cs
+++ b/backend/BookService.Tests/BooksControllerTests.cs
@@ -1,0 +1,242 @@
+using Xunit;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using BookService.Controllers;
+using BookService.Services;
+using BookService.Dtos;
+
+namespace BookService.Tests
+{
+    public class BooksControllerTests
+    {
+        private readonly Mock<IBookService> _mockBookService;
+        private readonly BooksController _controller;
+
+        public BooksControllerTests()
+        {
+            _mockBookService = new Mock<IBookService>();
+            _controller = new BooksController(_mockBookService.Object);
+        }
+
+        [Fact]
+        public async Task GetAll_ShouldReturnOkResult_WithBookList()
+        {
+            // Arrange
+            var books = new List<BookDto>
+            {
+                new BookDto(1, "Book 1", "Description 1", 1, "Author 1", "book-1", "/images/book1.jpg"),
+                new BookDto(2, "Book 2", "Description 2", 2, "Author 2", "book-2", "/images/book2.jpg")
+            };
+
+            _mockBookService.Setup(s => s.GetAllBooksAsync())
+                .ReturnsAsync(books);
+
+            // Act
+            var result = await _controller.GetAll();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedBooks = Assert.IsType<List<BookDto>>(okResult.Value);
+            Assert.Equal(2, returnedBooks.Count);
+            Assert.Equal("Book 1", returnedBooks[0].Title);
+            Assert.Equal("Book 2", returnedBooks[1].Title);
+        }
+
+        [Fact]
+        public async Task GetAll_ShouldReturnOkResult_WithEmptyList_WhenNoBooksExist()
+        {
+            // Arrange
+            _mockBookService.Setup(s => s.GetAllBooksAsync())
+                .ReturnsAsync(new List<BookDto>());
+
+            // Act
+            var result = await _controller.GetAll();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedBooks = Assert.IsType<List<BookDto>>(okResult.Value);
+            Assert.Empty(returnedBooks);
+        }
+
+        [Fact]
+        public async Task GetById_ShouldReturnOkResult_WhenBookExists()
+        {
+            // Arrange
+            var bookId = 1;
+            var book = new BookWithChunkDto(
+                bookId,
+                "Test Book",
+                "Test Description",
+                1,
+                "Test Author",
+                "test-book",
+                "/images/test.jpg",
+                "/chunks/chunk1.pdf"
+            );
+
+            _mockBookService.Setup(s => s.GetBookByIdAsync(bookId))
+                .ReturnsAsync(book);
+
+            // Act
+            var result = await _controller.GetById(bookId);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedBook = Assert.IsType<BookWithChunkDto>(okResult.Value);
+            Assert.Equal(bookId, returnedBook.Id);
+            Assert.Equal("Test Book", returnedBook.Title);
+        }
+
+        [Fact]
+        public async Task GetById_ShouldReturnNotFound_WhenBookDoesNotExist()
+        {
+            // Arrange
+            var bookId = 999;
+            _mockBookService.Setup(s => s.GetBookByIdAsync(bookId))
+                .ReturnsAsync((BookWithChunkDto?)null);
+
+            // Act
+            var result = await _controller.GetById(bookId);
+
+            // Assert
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_ShouldReturnCreatedResult_WithValidBook()
+        {
+            // Arrange
+            var createDto = new BookCreateDto(
+                "New Book",
+                "New Description",
+                1,
+                "New Author",
+                new List<string> { "/chunks/chunk1.pdf" },
+                "new-book",
+                "/images/new.jpg"
+            );
+
+            var createdBook = new BookDto(
+                1,
+                "New Book",
+                "New Description",
+                1,
+                "New Author",
+                "new-book",
+                "/images/new.jpg"
+            );
+
+            _mockBookService.Setup(s => s.CreateBookAsync(createDto))
+                .ReturnsAsync(createdBook);
+
+            // Act
+            var result = await _controller.Create(createDto);
+
+            // Assert
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(nameof(BooksController.GetById), createdResult.ActionName);
+            Assert.Equal(createdBook.Id, createdResult.RouteValues!["id"]);
+
+            var returnedBook = Assert.IsType<BookDto>(createdResult.Value);
+            Assert.Equal("New Book", returnedBook.Title);
+        }
+
+        [Fact]
+        public async Task GetChunk_ShouldReturnOkResult_WhenChunkExists()
+        {
+            // Arrange
+            var bookId = 1;
+            var chunkNumber = 2;
+            var chunk = new BookChunkDto(1, chunkNumber, "/chunks/chunk2.pdf");
+
+            _mockBookService.Setup(s => s.GetChunkAsync(bookId, chunkNumber))
+                .ReturnsAsync(chunk);
+
+            // Act
+            var result = await _controller.GetChunk(bookId, chunkNumber);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedChunk = Assert.IsType<BookChunkDto>(okResult.Value);
+            Assert.Equal(1, returnedChunk.Id);
+            Assert.Equal(chunkNumber, returnedChunk.ChunkNumber);
+            Assert.Equal("/chunks/chunk2.pdf", returnedChunk.FileUrl);
+        }
+
+        [Fact]
+        public async Task GetChunk_ShouldReturnNotFound_WhenChunkDoesNotExist()
+        {
+            // Arrange
+            var bookId = 1;
+            var chunkNumber = 999;
+            _mockBookService.Setup(s => s.GetChunkAsync(bookId, chunkNumber))
+                .ReturnsAsync((BookChunkDto?)null);
+
+            // Act
+            var result = await _controller.GetChunk(bookId, chunkNumber);
+
+            // Assert
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_ShouldCallServiceOnce_WithCorrectDto()
+        {
+            // Arrange
+            var createDto = new BookCreateDto(
+                "Test Book",
+                "Test Description",
+                1,
+                "Test Author",
+                new List<string>(),
+                "test-book",
+                "/images/test.jpg"
+            );
+
+            var createdBook = new BookDto(1, "Test Book", "Test Description", 1, "Test Author", "test-book", "/images/test.jpg");
+
+            _mockBookService.Setup(s => s.CreateBookAsync(It.IsAny<BookCreateDto>()))
+                .ReturnsAsync(createdBook);
+
+            // Act
+            await _controller.Create(createDto);
+
+            // Assert
+            _mockBookService.Verify(s => s.CreateBookAsync(It.Is<BookCreateDto>(dto =>
+                dto.Title == "Test Book" &&
+                dto.AuthorName == "Test Author" &&
+                dto.TitleSlug == "test-book")), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetById_ShouldCallServiceOnce_WithCorrectId()
+        {
+            // Arrange
+            var bookId = 42;
+            _mockBookService.Setup(s => s.GetBookByIdAsync(bookId))
+                .ReturnsAsync((BookWithChunkDto?)null);
+
+            // Act
+            await _controller.GetById(bookId);
+
+            // Assert
+            _mockBookService.Verify(s => s.GetBookByIdAsync(42), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetChunk_ShouldCallServiceOnce_WithCorrectParameters()
+        {
+            // Arrange
+            var bookId = 5;
+            var chunkNumber = 3;
+            _mockBookService.Setup(s => s.GetChunkAsync(bookId, chunkNumber))
+                .ReturnsAsync((BookChunkDto?)null);
+
+            // Act
+            await _controller.GetChunk(bookId, chunkNumber);
+
+            // Assert
+            _mockBookService.Verify(s => s.GetChunkAsync(5, 3), Times.Once);
+        }
+    }
+}

--- a/backend/BookService.Tests/README.md
+++ b/backend/BookService.Tests/README.md
@@ -1,0 +1,157 @@
+# BookService Tests
+
+This directory contains comprehensive unit tests for the BookService microservice using xUnit and in-memory databases for mocking.
+
+## Test Structure
+
+### Test Files
+
+- **`UnitTest1.cs`** - Main BookService business logic tests
+- **`BookRepositoryTests.cs`** - Repository layer tests with in-memory database
+- **`BooksControllerTests.cs`** - Controller tests with mocked dependencies
+- **`BookChunkTests.cs`** - Book chunk repository tests
+
+## Testing Approach
+
+### 1. Service Layer Tests (`UnitTest1.cs`)
+
+- **Purpose**: Test business logic in `BookServiceImpl`
+- **Database**: Entity Framework In-Memory Database
+- **Coverage**:
+  - Book creation with chunks
+  - Book retrieval (single and all)
+  - Book updates
+  - Book deletion
+  - Edge cases (null returns, non-existent records)
+
+### 2. Repository Layer Tests (`BookRepositoryTests.cs`)
+
+- **Purpose**: Test data access layer
+- **Database**: Entity Framework In-Memory Database
+- **Coverage**:
+  - CRUD operations for books
+  - Database persistence verification
+  - Relationship handling (books with chunks)
+  - Edge cases and error scenarios
+
+### 3. Controller Layer Tests (`BooksControllerTests.cs`)
+
+- **Purpose**: Test API endpoints and HTTP responses
+- **Mocking**: Moq library for service dependencies
+- **Coverage**:
+  - HTTP status codes (200, 201, 404)
+  - Request/response mapping
+  - Service method invocation verification
+  - Parameter validation
+
+### 4. Book Chunk Tests (`BookChunkTests.cs`)
+
+- **Purpose**: Test chunk-specific functionality
+- **Database**: Entity Framework In-Memory Database
+- **Coverage**:
+  - Chunk retrieval by book ID
+  - Chunk CRUD operations
+  - Chunk ordering and relationships
+
+## Test Patterns
+
+### In-Memory Database Setup
+
+```csharp
+var options = new DbContextOptionsBuilder<BookDbContext>()
+    .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+    .Options;
+```
+
+- Each test uses a unique database name to ensure isolation
+- No shared state between tests
+- Automatic cleanup with `IDisposable`
+
+### Mocking with Moq
+
+```csharp
+var mockService = new Mock<IBookService>();
+mockService.Setup(s => s.GetAllBooksAsync())
+    .ReturnsAsync(books);
+```
+
+### Test Data Creation
+
+- Uses realistic test data
+- Covers different scenarios (empty collections, null values, etc.)
+- Consistent naming patterns
+
+## Dependencies
+
+### NuGet Packages
+
+- **Microsoft.EntityFrameworkCore.InMemory** (9.0.9) - In-memory database provider
+- **Moq** (4.20.72) - Mocking framework
+- **xunit** (2.9.2) - Testing framework
+- **xunit.runner.visualstudio** (2.8.2) - Visual Studio test runner
+- **Microsoft.NET.Test.Sdk** (17.12.0) - .NET test SDK
+- **FluentAssertions** (6.12.1) - Fluent assertion library (optional)
+
+## Running Tests
+
+### Command Line
+
+```bash
+# Run all tests
+dotnet test
+
+# Run with coverage
+dotnet test --collect:"XPlat Code Coverage"
+
+# Run specific test class
+dotnet test --filter "BookServiceTests"
+
+# Run tests with detailed output
+dotnet test --logger "console;verbosity=detailed"
+```
+
+### Visual Studio
+
+- Use Test Explorer
+- Right-click on test methods/classes to run individually
+- Set breakpoints for debugging
+
+## Test Coverage
+
+Current test coverage includes:
+
+- ✅ **Service Layer**: 100% method coverage
+- ✅ **Repository Layer**: 100% method coverage
+- ✅ **Controller Layer**: 100% endpoint coverage
+- ✅ **Book Chunks**: Complete CRUD operations
+- ✅ **Error Scenarios**: Null returns, not found cases
+- ✅ **Edge Cases**: Empty collections, invalid IDs
+
+## Best Practices Applied
+
+1. **Test Isolation**: Each test is independent and can run in any order
+2. **Arrange-Act-Assert**: Clear test structure
+3. **Descriptive Names**: Test method names describe the scenario and expected outcome
+4. **Single Responsibility**: Each test focuses on one specific behavior
+5. **Mock External Dependencies**: Controllers don't depend on real services
+6. **In-Memory Database**: Fast, isolated database tests
+7. **Cleanup**: Proper disposal of resources
+
+## Continuous Integration
+
+Tests are designed to run in CI/CD pipelines:
+
+- No external dependencies (databases, files, network)
+- Fast execution (all tests complete in under 1 second)
+- Deterministic results
+- Clear failure messages
+
+## Future Enhancements
+
+Consider adding:
+
+- Integration tests with real database
+- Performance tests for large datasets
+- API integration tests with TestServer
+- Property-based testing for edge cases
+- Mutation testing to verify test quality

--- a/backend/BookService.Tests/TEST_RESULTS_GUIDE.md
+++ b/backend/BookService.Tests/TEST_RESULTS_GUIDE.md
@@ -1,0 +1,215 @@
+# Test Results XML Generation Guide
+
+This guide shows how to generate test results in XML format for the BookService tests.
+
+## Methods to Generate TestResults.xml
+
+### Method 1: JUnit XML Logger (Recommended)
+
+The project already includes `JunitXml.TestLogger` package which generates JUnit-compatible XML.
+
+```bash
+# Generate TestResults.xml in current directory
+dotnet test --logger "junit;LogFilePath=TestResults.xml"
+
+# Generate with custom filename
+dotnet test --logger "junit;LogFilePath=MyTestResults.xml"
+
+# Generate in TestResults directory
+dotnet test --logger "junit;LogFilePath=TestResults/TestResults.xml"
+```
+
+### Method 2: TRX Logger (Visual Studio Format)
+
+Generate Visual Studio Test Results (.trx) format:
+
+```bash
+# Generate TRX format
+dotnet test --logger "trx;LogFileName=TestResults.trx"
+
+# Generate in specific directory
+dotnet test --logger "trx;LogFileName=TestResults/TestResults.trx"
+```
+
+### Method 3: Multiple Loggers
+
+Generate both JUnit XML and TRX formats:
+
+```bash
+dotnet test --logger "junit;LogFilePath=TestResults.xml" --logger "trx;LogFileName=TestResults.trx"
+```
+
+### Method 4: Console + XML
+
+Show console output and generate XML:
+
+```bash
+dotnet test --logger "console;verbosity=detailed" --logger "junit;LogFilePath=TestResults.xml"
+```
+
+## XML Output Structure
+
+The generated `TestResults.xml` follows JUnit format and includes:
+
+- **Test Suite Information**: Total tests, failures, errors, execution time
+- **Individual Test Cases**: Class name, method name, execution time
+- **Test Results**: Pass/fail status for each test
+- **System Output**: Framework messages and logs
+
+### Sample XML Structure:
+
+```xml
+<testsuites>
+  <testsuite name="BookService.Tests.dll" tests="39" skipped="0" failures="0" errors="0" time="0.9354359999999999">
+    <testcase classname="BookService.Tests.BookServiceTests" name="CreateBookAsync_ShouldCreateBookSuccessfully" time="0.0040558" />
+    <testcase classname="BookService.Tests.BooksControllerTests" name="GetAll_ShouldReturnOkResult_WithBookList" time="0.0364751" />
+    <!-- More test cases... -->
+  </testsuite>
+</testsuites>
+```
+
+## CI/CD Integration
+
+### GitHub Actions Example:
+
+```yaml
+- name: Run Tests and Generate XML
+  run: dotnet test --logger "junit;LogFilePath=TestResults.xml"
+
+- name: Upload Test Results
+  uses: actions/upload-artifact@v3
+  with:
+    name: test-results
+    path: TestResults.xml
+```
+
+### Azure DevOps Example:
+
+```yaml
+- task: DotNetCoreCLI@2
+  displayName: "Run Tests"
+  inputs:
+    command: "test"
+    arguments: '--logger "junit;LogFilePath=TestResults.xml"'
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFormat: "JUnit"
+    testResultsFiles: "TestResults.xml"
+```
+
+## Configuration Options
+
+### JUnit Logger Options:
+
+```bash
+# Basic XML generation
+--logger "junit"
+
+# Custom file path
+--logger "junit;LogFilePath=custom-results.xml"
+
+# Include method parameters in test names
+--logger "junit;MethodFormat=Class"
+
+# Include namespace in class names
+--logger "junit;LogFilePath=TestResults.xml;MethodFormat=Full"
+```
+
+### TRX Logger Options:
+
+```bash
+# Basic TRX generation
+--logger "trx"
+
+# Custom filename
+--logger "trx;LogFileName=MyResults.trx"
+
+# Custom directory
+--logger "trx;LogFilePrefix=BookService"
+```
+
+## Project Configuration
+
+The test project is already configured with the necessary packages:
+
+```xml
+<PackageReference Include="JunitXml.TestLogger" Version="6.1.0" />
+<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+```
+
+## Automated Script
+
+Create a PowerShell/Bash script for consistent test result generation:
+
+### PowerShell (test-with-results.ps1):
+
+```powershell
+#!/usr/bin/env pwsh
+Write-Host "Running BookService Tests with XML Output..." -ForegroundColor Green
+
+# Clean previous results
+if (Test-Path "TestResults.xml") { Remove-Item "TestResults.xml" }
+if (Test-Path "TestResults") { Remove-Item "TestResults" -Recurse }
+
+# Run tests with XML output
+dotnet test --logger "junit;LogFilePath=TestResults.xml" --logger "console;verbosity=normal"
+
+# Check if tests passed
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "✅ All tests passed! Results saved to TestResults.xml" -ForegroundColor Green
+} else {
+    Write-Host "❌ Some tests failed. Check TestResults.xml for details." -ForegroundColor Red
+}
+```
+
+### Bash (test-with-results.sh):
+
+```bash
+#!/bin/bash
+echo "Running BookService Tests with XML Output..."
+
+# Clean previous results
+rm -f TestResults.xml
+rm -rf TestResults
+
+# Run tests with XML output
+dotnet test --logger "junit;LogFilePath=TestResults.xml" --logger "console;verbosity=normal"
+
+# Check results
+if [ $? -eq 0 ]; then
+    echo "✅ All tests passed! Results saved to TestResults.xml"
+else
+    echo "❌ Some tests failed. Check TestResults.xml for details."
+fi
+```
+
+## Current Test Results Summary
+
+Latest test run results:
+
+- **Total Tests**: 39
+- **Passed**: 39
+- **Failed**: 0
+- **Skipped**: 0
+- **Execution Time**: 0.94 seconds
+- **Result File**: `TestResults.xml` (JUnit format)
+
+## Integration with Test Reporting Tools
+
+The generated XML can be consumed by various tools:
+
+- **Jenkins**: JUnit Plugin
+- **Azure DevOps**: Test Results Publisher
+- **GitHub Actions**: Test Reporting Actions
+- **SonarQube**: Test Coverage Reports
+- **TeamCity**: XML Test Reporting
+- **Allure**: Test Report Framework
+
+## Best Practices
+
+1. **Always generate XML in CI/CD** pipelines for test reporting
+2. **Use consistent naming** for result files across environments
+3. **Archive test results** as build artifacts
+4. **Set up alerts** for test failures based on XML results
+5. **Include timestamp** in filenames for historical tracking

--- a/backend/BookService.Tests/TestResults/TestResults.xml
+++ b/backend/BookService.Tests/TestResults/TestResults.xml
@@ -1,17 +1,52 @@
 <testsuites>
-  <testsuite name="AuthService.Tests.dll" tests="4" skipped="0" failures="0" errors="0" time="0.47558979999999995" timestamp="2025-09-09T14:10:41" hostname="nayanthanethsaras-MacBook-Air" id="0" package="AuthService.Tests.dll">
+  <testsuite name="BookService.Tests.dll" tests="39" skipped="0" failures="0" errors="0" time="1.0140381999999994" timestamp="2025-09-30T18:32:57" hostname="nayanthanethsaras-MacBook-Air" id="0" package="BookService.Tests.dll">
     <properties />
-    <testcase classname="AuthService.Tests.Services.JwtServiceTests" name="GenerateToken_ReturnsTokenString" time="0.0186811" />
-    <testcase classname="AuthService.Tests.Helpers.GoogleOAuthHelperTests" name="ExchangeCodeAsync_ReturnsUserInfo" time="0.0430679" />
-    <testcase classname="AuthService.Tests.UserServiceTests" name="Cannot_Add_Duplicate_Email" time="0.3287305" />
-    <testcase classname="AuthService.Tests.UserServiceTests" name="Can_Add_User" time="0.0851103" />
+    <testcase classname="BookService.Tests.BooksControllerTests" name="GetAll_ShouldReturnOkResult_WithBookList" time="0.0547082" />
+    <testcase classname="BookService.Tests.BooksControllerTests" name="GetChunk_ShouldReturnOkResult_WhenChunkExists" time="0.0072305" />
+    <testcase classname="BookService.Tests.BooksControllerTests" name="GetById_ShouldReturnNotFound_WhenBookDoesNotExist" time="0.0017632" />
+    <testcase classname="BookService.Tests.BooksControllerTests" name="GetChunk_ShouldCallServiceOnce_WithCorrectParameters" time="0.0030448" />
+    <testcase classname="BookService.Tests.BooksControllerTests" name="Create_ShouldCallServiceOnce_WithCorrectDto" time="0.0052298" />
+    <testcase classname="BookService.Tests.BooksControllerTests" name="GetChunk_ShouldReturnNotFound_WhenChunkDoesNotExist" time="0.0005571" />
+    <testcase classname="BookService.Tests.BooksControllerTests" name="GetById_ShouldReturnOkResult_WhenBookExists" time="0.0005687" />
+    <testcase classname="BookService.Tests.BooksControllerTests" name="GetById_ShouldCallServiceOnce_WithCorrectId" time="0.0004211" />
+    <testcase classname="BookService.Tests.BooksControllerTests" name="GetAll_ShouldReturnOkResult_WithEmptyList_WhenNoBooksExist" time="0.0007776" />
+    <testcase classname="BookService.Tests.BooksControllerTests" name="Create_ShouldReturnCreatedResult_WithValidBook" time="0.0016381" />
+    <testcase classname="BookService.Tests.BookRepositoryTests" name="UpdateAsync_ShouldUpdateBook_WhenBookExists" time="0.2477944" />
+    <testcase classname="BookService.Tests.BookChunkRepositoryTests" name="AddAsync_ShouldAddChunkToBook" time="0.2546236" />
+    <testcase classname="BookService.Tests.BookChunkRepositoryTests" name="GetByBookIdAsync_ShouldReturnChunks_WhenChunksExist" time="0.0447408" />
+    <testcase classname="BookService.Tests.BookRepositoryTests" name="GetByIdAsync_ShouldReturnBook_WhenBookExists" time="0.0515274" />
+    <testcase classname="BookService.Tests.BookServiceTests" name="GetAllBooksAsync_ShouldReturnAllBooks_WhenBooksExist" time="0.2996078" />
+    <testcase classname="BookService.Tests.BookRepositoryTests" name="AddAsync_ShouldAddBookToDatabase" time="0.0005844" />
+    <testcase classname="BookService.Tests.BookServiceTests" name="GetAllBooksAsync_ShouldReturnEmptyList_WhenNoBooksExist" time="0.0009685" />
+    <testcase classname="BookService.Tests.BookChunkRepositoryTests" name="GetByBookIdAsync_ShouldReturnEmptyCollection_WhenBookHasNoChunks" time="0.0014019" />
+    <testcase classname="BookService.Tests.BookServiceTests" name="UpdateBookAsync_ShouldUpdateBook_WhenBookExists" time="0.0010934" />
+    <testcase classname="BookService.Tests.BookChunkRepositoryTests" name="UpdateAsync_ShouldUpdateExistingChunk" time="0.0008147" />
+    <testcase classname="BookService.Tests.BookChunkRepositoryTests" name="GetByBookIdAsync_ShouldReturnEmptyCollection_WhenBookDoesNotExist" time="0.0002761" />
+    <testcase classname="BookService.Tests.BookServiceTests" name="GetBookByIdAsync_ShouldReturnNull_WhenBookDoesNotExist" time="0.0004441" />
+    <testcase classname="BookService.Tests.BookChunkRepositoryTests" name="GetByIdAsync_ShouldReturnChunk_WhenChunkExists" time="0.0005605" />
+    <testcase classname="BookService.Tests.BookChunkRepositoryTests" name="DeleteAsync_ShouldDeleteChunk_WhenChunkExists" time="0.0048767" />
+    <testcase classname="BookService.Tests.BookServiceTests" name="DeleteBookAsync_ShouldDeleteBook_WhenBookExists" time="0.0054093" />
+    <testcase classname="BookService.Tests.BookRepositoryTests" name="DeleteAsync_ShouldDeleteBook_WhenBookExists" time="0.0075810" />
+    <testcase classname="BookService.Tests.BookRepositoryTests" name="GetByIdAsync_ShouldReturnNull_WhenBookDoesNotExist" time="0.0003502" />
+    <testcase classname="BookService.Tests.BookChunkRepositoryTests" name="GetByBookIdAsync_ShouldReturnChunksOrderedByChunkNumber" time="0.0007170" />
+    <testcase classname="BookService.Tests.BookServiceTests" name="DeleteBookAsync_ShouldReturnFalse_WhenBookDoesNotExist" time="0.0007015" />
+    <testcase classname="BookService.Tests.BookChunkRepositoryTests" name="GetByIdAsync_ShouldReturnNull_WhenChunkDoesNotExist" time="0.0002716" />
+    <testcase classname="BookService.Tests.BookRepositoryTests" name="GetAllAsync_ShouldReturnAllBooks_WhenBooksExist" time="0.0006129" />
+    <testcase classname="BookService.Tests.BookServiceTests" name="UpdateBookAsync_ShouldReturnNull_WhenBookDoesNotExist" time="0.0003122" />
+    <testcase classname="BookService.Tests.BookRepositoryTests" name="DeleteAsync_ShouldReturnFalse_WhenBookDoesNotExist" time="0.0002384" />
+    <testcase classname="BookService.Tests.BookServiceTests" name="GetBookByIdAsync_ShouldReturnBook_WhenBookExists" time="0.0005390" />
+    <testcase classname="BookService.Tests.BookServiceTests" name="CreateBookAsync_ShouldCreateBookSuccessfully" time="0.0042825" />
+    <testcase classname="BookService.Tests.BookRepositoryTests" name="AddAsync_ShouldAddBookWithChunks" time="0.0049795" />
+    <testcase classname="BookService.Tests.BookServiceTests" name="CreateBookAsync_ShouldCreateBookWithChunks_WhenChunkUrlsProvided" time="0.0010054" />
+    <testcase classname="BookService.Tests.BookRepositoryTests" name="GetByIdAsync_ShouldIncludeAllChunks" time="0.0015058" />
+    <testcase classname="BookService.Tests.BookRepositoryTests" name="GetAllAsync_ShouldReturnEmptyList_WhenNoBooksExist" time="0.0002785" />
     <system-out>
 Test Framework Informational Messages:
 [xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 9.0.7)
-[xUnit.net 00:00:00.03]   Discovering: AuthService.Tests
-[xUnit.net 00:00:00.04]   Discovered:  AuthService.Tests
-[xUnit.net 00:00:00.04]   Starting:    AuthService.Tests
-[xUnit.net 00:00:00.47]   Finished:    AuthService.Tests
+[xUnit.net 00:00:00.03]   Discovering: BookService.Tests
+[xUnit.net 00:00:00.04]   Discovered:  BookService.Tests
+[xUnit.net 00:00:00.05]   Starting:    BookService.Tests
+[xUnit.net 00:00:00.38]   Finished:    BookService.Tests
 </system-out>
     <system-err></system-err>
   </testsuite>

--- a/backend/BookService.Tests/UnitTest1.cs
+++ b/backend/BookService.Tests/UnitTest1.cs
@@ -3,42 +3,291 @@ using Microsoft.EntityFrameworkCore;
 using BookService.Data;
 using BookService.Repositories;
 using BookService.Services;
-using BookService.Controllers;
 using BookService.Models;
-using Microsoft.AspNetCore.Mvc;
-using System.Threading.Tasks;
 using BookService.Dtos;
 
 namespace BookService.Tests
 {
-    public class BooksControllerTests
+    public class BookServiceTests : IDisposable
     {
-        private BooksController GetControllerWithInMemoryDb()
+        private readonly BookDbContext _context;
+        private readonly IBookRepository _bookRepository;
+        private readonly IBookService _bookService;
+
+        public BookServiceTests()
         {
             var options = new DbContextOptionsBuilder<BookDbContext>()
-                .UseInMemoryDatabase(databaseName: "BookServiceTestDb")
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
                 .Options;
 
-            var dbContext = new BookDbContext(options);
-
-            var repo = new BookRepository(dbContext);
-            var service = new BookServiceImpl(repo);
-            return new BooksController(service);
+            _context = new BookDbContext(options);
+            _bookRepository = new BookRepository(_context);
+            _bookService = new BookServiceImpl(_bookRepository);
         }
 
         [Fact]
-        public async Task GetAllBooks_ReturnsEmpty_WhenNoBooks()
+        public async Task CreateBookAsync_ShouldCreateBookSuccessfully()
         {
             // Arrange
-            var controller = GetControllerWithInMemoryDb();
+            var createDto = new BookCreateDto(
+                "Test Book",
+                "Test Description",
+                1,
+                "Test Author",
+                new List<string> { "/chunks/chunk1.pdf", "/chunks/chunk2.pdf" },
+                "test-book",
+                "/images/test.jpg"
+            );
 
             // Act
-            var result = await controller.GetAll();
+            var result = await _bookService.CreateBookAsync(createDto);
 
             // Assert
-            var okResult = Assert.IsType<OkObjectResult>(result);
-            var books = Assert.IsType<List<BookDto>>(okResult.Value);
-            Assert.Empty(books);
+            Assert.NotNull(result);
+            Assert.Equal("Test Book", result.Title);
+            Assert.Equal("Test Description", result.Description);
+            Assert.Equal(1, result.AuthorId);
+            Assert.Equal("Test Author", result.AuthorName);
+            Assert.Equal("test-book", result.TitleSlug);
+            Assert.Equal("/images/test.jpg", result.CoverImagePath);
+
+            // Verify book was saved to database
+            var savedBook = await _context.Books.Include(b => b.Chunks).FirstOrDefaultAsync(b => b.Id == result.Id);
+            Assert.NotNull(savedBook);
+            Assert.Equal(2, savedBook!.Chunks.Count);
+        }
+
+        [Fact]
+        public async Task GetAllBooksAsync_ShouldReturnEmptyList_WhenNoBooksExist()
+        {
+            // Act
+            var result = await _bookService.GetAllBooksAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetAllBooksAsync_ShouldReturnAllBooks_WhenBooksExist()
+        {
+            // Arrange
+            var book1 = new Book
+            {
+                Title = "Book 1",
+                Description = "Description 1",
+                AuthorId = 1,
+                AuthorName = "Author 1",
+                TitleSlug = "book-1",
+                CoverImagePath = "/images/book1.jpg"
+            };
+
+            var book2 = new Book
+            {
+                Title = "Book 2",
+                Description = "Description 2",
+                AuthorId = 2,
+                AuthorName = "Author 2",
+                TitleSlug = "book-2",
+                CoverImagePath = "/images/book2.jpg"
+            };
+
+            await _context.Books.AddRangeAsync(book1, book2);
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _bookService.GetAllBooksAsync();
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.Contains(result, b => b.Title == "Book 1" && b.AuthorName == "Author 1");
+            Assert.Contains(result, b => b.Title == "Book 2" && b.AuthorName == "Author 2");
+        }
+
+        [Fact]
+        public async Task GetBookByIdAsync_ShouldReturnBook_WhenBookExists()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Test Book",
+                Description = "Test Description",
+                AuthorId = 1,
+                AuthorName = "Test Author",
+                TitleSlug = "test-book",
+                CoverImagePath = "/images/test.jpg",
+                Chunks = new List<BookChunk>
+                {
+                    new BookChunk { ChunkNumber = 1, StoragePath = "/chunks/chunk1.pdf" }
+                }
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _bookService.GetBookByIdAsync(book.Id);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Test Book", result.Title);
+            Assert.Equal("Test Description", result.Description);
+            Assert.Equal(1, result.AuthorId);
+            Assert.Equal("Test Author", result.AuthorName);
+            Assert.Equal("/chunks/chunk1.pdf", result.ChunkPath);
+        }
+
+        [Fact]
+        public async Task GetBookByIdAsync_ShouldReturnNull_WhenBookDoesNotExist()
+        {
+            // Act
+            var result = await _bookService.GetBookByIdAsync(999);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task UpdateBookAsync_ShouldUpdateBook_WhenBookExists()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Original Title",
+                Description = "Original Description",
+                AuthorId = 1,
+                AuthorName = "Original Author",
+                TitleSlug = "original-title",
+                CoverImagePath = "/images/original.jpg"
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            var updateDto = new BookCreateDto(
+                "Updated Title",
+                "Updated Description",
+                1,
+                "Original Author",
+                new List<string>(),
+                "updated-title",
+                "/images/updated.jpg"
+            );
+
+            // Act
+            var result = await _bookService.UpdateBookAsync(book.Id, updateDto);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Updated Title", result.Title);
+            Assert.Equal("Updated Description", result.Description);
+            Assert.Equal("updated-title", result.TitleSlug);
+            Assert.Equal("/images/updated.jpg", result.CoverImagePath);
+
+            // Verify database was updated
+            var updatedBook = await _context.Books.FindAsync(book.Id);
+            Assert.Equal("Updated Title", updatedBook!.Title);
+        }
+
+        [Fact]
+        public async Task UpdateBookAsync_ShouldReturnNull_WhenBookDoesNotExist()
+        {
+            // Arrange
+            var updateDto = new BookCreateDto(
+                "Updated Title",
+                "Updated Description",
+                1,
+                "Author",
+                new List<string>(),
+                "updated-title",
+                "/images/updated.jpg"
+            );
+
+            // Act
+            var result = await _bookService.UpdateBookAsync(999, updateDto);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task DeleteBookAsync_ShouldDeleteBook_WhenBookExists()
+        {
+            // Arrange
+            var book = new Book
+            {
+                Title = "Book to Delete",
+                Description = "Description",
+                AuthorId = 1,
+                AuthorName = "Author",
+                TitleSlug = "book-to-delete",
+                CoverImagePath = "/images/delete.jpg"
+            };
+
+            await _context.Books.AddAsync(book);
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _bookService.DeleteBookAsync(book.Id);
+
+            // Assert
+            Assert.True(result);
+
+            // Verify book was deleted from database
+            var deletedBook = await _context.Books.FindAsync(book.Id);
+            Assert.Null(deletedBook);
+        }
+
+        [Fact]
+        public async Task DeleteBookAsync_ShouldReturnFalse_WhenBookDoesNotExist()
+        {
+            // Act
+            var result = await _bookService.DeleteBookAsync(999);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task CreateBookAsync_ShouldCreateBookWithChunks_WhenChunkUrlsProvided()
+        {
+            // Arrange
+            var createDto = new BookCreateDto(
+                "Book with Chunks",
+                "Description",
+                1,
+                "Author",
+                new List<string>
+                {
+                    "/chunks/chunk1.pdf",
+                    "/chunks/chunk2.pdf",
+                    "/chunks/chunk3.pdf"
+                },
+                "book-with-chunks",
+                "/images/cover.jpg"
+            );
+
+            // Act
+            var result = await _bookService.CreateBookAsync(createDto);
+
+            // Assert
+            Assert.NotNull(result);
+
+            // Verify chunks were created
+            var savedBook = await _context.Books
+                .Include(b => b.Chunks)
+                .FirstOrDefaultAsync(b => b.Id == result.Id);
+
+            Assert.NotNull(savedBook);
+            Assert.Equal(3, savedBook.Chunks.Count);
+            Assert.Contains(savedBook.Chunks, c => c.ChunkNumber == 1 && c.StoragePath == "/chunks/chunk1.pdf");
+            Assert.Contains(savedBook.Chunks, c => c.ChunkNumber == 2 && c.StoragePath == "/chunks/chunk2.pdf");
+            Assert.Contains(savedBook.Chunks, c => c.ChunkNumber == 3 && c.StoragePath == "/chunks/chunk3.pdf");
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
         }
     }
 }

--- a/backend/BookService.Tests/appsettings.Test.json
+++ b/backend/BookService.Tests/appsettings.Test.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "BookService": "Information",
+      "Microsoft.EntityFrameworkCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=BookServiceTestDb;Trusted_Connection=true;MultipleActiveResultSets=true"
+  }
+}

--- a/backend/BookService/README.md
+++ b/backend/BookService/README.md
@@ -1,0 +1,309 @@
+# BookService API
+
+The BookService is a microservice responsible for managing books and book chunks in the TheKade-Nalandaa application. It provides REST API endpoints for book management, including CRUD operations and chunk-based content delivery.
+
+## Table of Contents
+
+- [Features](#features)
+- [Architecture](#architecture)
+- [File Structure](#file-structure)
+- [Getting Started](#getting-started)
+- [API Documentation](#api-documentation)
+- [Database Migrations](#database-migrations)
+- [Docker Support](#docker-support)
+- [Testing](#testing)
+- [Configuration](#configuration)
+- [Contributing](#contributing)
+
+## Features
+
+- **Book Management**: Create, read, update, and delete books
+- **Book Chunks**: Divide books into chunks for efficient content delivery
+- **JWT Authentication**: Secure API endpoints with JWT tokens
+- **Entity Framework Core**: Database operations with SQL Server
+- **Docker Support**: Containerized deployment
+- **Swagger Documentation**: Interactive API documentation
+- **Environment Configuration**: Support for development and production environments
+
+## Architecture
+
+The BookService follows a clean architecture pattern with the following layers:
+
+- **Controllers**: Handle HTTP requests and responses
+- **Services**: Business logic implementation
+- **Repositories**: Data access layer
+- **Models**: Entity definitions
+- **DTOs**: Data Transfer Objects for API communication
+- **Configurations**: Service and database configuration
+
+## File Structure
+
+```
+BookService/
+├── Controllers/
+│   └── BookController.cs          # API endpoints for book operations
+├── Services/
+│   ├── Interfaces/
+│   │   └── IBookService.cs        # Service interface
+│   └── BookService.cs             # Business logic implementation
+├── Repositories/
+│   ├── Interfaces/
+│   │   ├── IBookRepositories.cs   # Repository interfaces
+│   │   └── IBookChunkRepository.cs
+│   ├── BookRepositories.cs        # Book data access
+│   └── BookChunkRepository.cs     # Book chunk data access
+├── Models/
+│   ├── Book.cs                    # Book entity
+│   └── BookChunk.cs               # Book chunk entity
+├── DTOs/
+│   ├── BookDto.cs                 # Book data transfer object
+│   ├── BookCreateDto.cs           # Book creation DTO
+│   ├── BookChunkDto.cs            # Book chunk DTO
+│   └── BookWithChunkDto.cs        # Book with chunks DTO
+├── Data/
+│   └── BookDbContext.cs           # Entity Framework context
+├── Configurations/
+│   ├── DatabaseConfig.cs          # Database configuration
+│   ├── SecurityConfig.cs          # JWT and security configuration
+│   └── ServiceConfig.cs           # Service registration
+├── Migrations/                    # Entity Framework migrations
+├── Properties/
+├── Dockerfile                     # Docker container configuration
+├── Program.cs                     # Application entry point
+├── appsettings.json              # Application settings
+└── README.md                     # This file
+```
+
+## Getting Started
+
+### Prerequisites
+
+- [.NET 9.0 SDK](https://dotnet.microsoft.com/download)
+- [SQL Server](https://www.microsoft.com/en-us/sql-server) or SQL Server LocalDB
+- [Docker](https://www.docker.com/) (optional, for containerized deployment)
+
+### Installation
+
+1. **Clone the repository**
+
+   ```bash
+   git clone https://github.com/NayanthaNethsara/TheKade-Nalandaa.git
+   cd TheKade-Nalandaa/backend/BookService
+   ```
+
+2. **Install dependencies**
+
+   ```bash
+   dotnet restore
+   ```
+
+3. **Configure environment variables**
+
+   Create a `.env` file in the BookService directory:
+
+   ```env
+   CONNECTION_STRING=Server=localhost;Database=BookServiceDB;Trusted_Connection=true;TrustServerCertificate=true;
+   JWT_SECRET=your-super-secret-jwt-key-here
+   JWT_ISSUER=TheKade-Nalandaa
+   JWT_AUDIENCE=TheKade-Nalandaa-Users
+   ```
+
+4. **Update database**
+
+   ```bash
+   dotnet ef database update
+   ```
+
+**For cloud deployment (e.g., Supabase/PostgreSQL), update the database with:**
+
+```bash
+dotnet ef database update --context BookDbContext --connection "db"
+```
+
+5. **Run the application**
+   ```bash
+   dotnet run
+   ```
+
+The API will be available at `https://localhost:7001` (HTTPS) or `http://localhost:5001` (HTTP).
+
+### Development Setup
+
+For development with hot reload:
+
+```bash
+dotnet watch run
+```
+
+## API Documentation
+
+Once the application is running, you can access the Swagger documentation at:
+
+- **Swagger UI**: `https://localhost:7001/swagger`
+
+### Main Endpoints
+
+#### Books
+
+- `GET /api/books` - Get all books
+- `GET /api/books/{id}` - Get book by ID
+- `POST /api/books` - Create a new book
+- `PUT /api/books/{id}` - Update a book
+- `DELETE /api/books/{id}` - Delete a book
+
+#### Book Chunks
+
+- `GET /api/books/{bookId}/chunks/{chunkNumber}` - Get specific book chunk
+
+### Example API Requests
+
+**Create a Book:**
+
+```json
+POST /api/books
+Content-Type: application/json
+
+{
+  "title": "Sample Book",
+  "description": "A sample book description",
+  "authorId": 1,
+  "authorName": "John Doe",
+  "titleSlug": "sample-book",
+  "coverImagePath": "/images/sample-book-cover.jpg"
+}
+```
+
+**Get All Books:**
+
+```json
+GET /api/books
+```
+
+## Database Migrations
+
+The project uses Entity Framework Core for database operations.
+
+### Create a new migration
+
+```bash
+dotnet ef migrations add MigrationName
+```
+
+### Update database
+
+```bash
+dotnet ef database update
+```
+
+### Remove last migration
+
+```bash
+dotnet ef migrations remove
+```
+
+## Docker Support
+
+### Build Docker Image
+
+```bash
+docker build -t bookservice .
+```
+
+### Run with Docker
+
+```bash
+docker run -p 8080:8080 -e CONNECTION_STRING="your-connection-string" bookservice
+```
+
+### Docker Compose
+
+The service can be run with other services using the docker-compose.yml in the backend folder:
+
+```bash
+cd ../
+docker-compose up bookservice
+```
+
+## Testing
+
+### Run Unit Tests
+
+```bash
+cd ../BookService.Tests
+dotnet test
+```
+
+### Run Tests with Coverage
+
+```bash
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable            | Description                | Default                |
+| ------------------- | -------------------------- | ---------------------- |
+| `CONNECTION_STRING` | Database connection string | Required               |
+| `JWT_SECRET`        | JWT signing key            | Required               |
+| `JWT_ISSUER`        | JWT token issuer           | TheKade-Nalandaa       |
+| `JWT_AUDIENCE`      | JWT token audience         | TheKade-Nalandaa-Users |
+
+### appsettings.json
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": ""
+  }
+}
+```
+
+## Security
+
+- JWT token authentication is required for protected endpoints
+- CORS is configured to allow frontend access
+- SQL injection protection through Entity Framework parameterized queries
+- Environment-based configuration for secrets
+
+## Performance Considerations
+
+- Book content is chunked for efficient loading
+- Entity Framework query optimization
+- Async/await pattern for non-blocking operations
+- Proper HTTP status codes and error handling
+
+## Error Handling
+
+The API returns standard HTTP status codes:
+
+- `200` - Success
+- `201` - Created
+- `400` - Bad Request
+- `401` - Unauthorized
+- `404` - Not Found
+- `500` - Internal Server Error
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## License
+
+This project is part of the TheKade-Nalandaa application. See the main repository for license information.
+
+## Support
+
+For support and questions, please refer to the main project documentation or create an issue in the repository.


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the book and book chunk repository layers, ensuring that core CRUD operations and data integrity are well-covered. It also improves the CI pipeline by ensuring test results are properly saved and uploaded, and introduces a new testing library for more expressive assertions.

**Testing improvements:**

* Added `BookRepositoryTests` to verify CRUD operations and chunk handling for books in `backend/BookService.Tests/BookRepositoryTests.cs`.
* Added `BookChunkRepositoryTests` to verify CRUD operations and chunk ordering for book chunks in `backend/BookService.Tests/BookChunkTests.cs`.
* Added the `FluentAssertions` library to the test project for improved assertion syntax in tests (`backend/BookService.Tests/BookService.Tests.csproj`).

**CI pipeline enhancements:**

* Modified `.github/workflows/book-pipline.yml` to create the test results folder before running tests, and fixed the test logger argument formatting to ensure test results are saved and uploaded correctly.