### PR TITLE
feat: Add automatic database migrations on service startup

### DIFF
--- a/backend/AuthService/Data/DbSeeder.cs
+++ b/backend/AuthService/Data/DbSeeder.cs
@@ -8,9 +8,8 @@ namespace AuthService.Data
     {
         public static async Task SeedAdminAsync(AuthDbContext db)
         {
-            // Make sure the DB is created
-            await db.Database.EnsureCreatedAsync();
-
+            // Note: Database migrations are now applied in Program.cs before seeding
+            
             // Check if any admin exists
             if (!await db.Users.AnyAsync(u => u.Role == Roles.Admin))
             {

--- a/backend/AuthService/Program.cs
+++ b/backend/AuthService/Program.cs
@@ -1,6 +1,7 @@
 using AuthService.Configurations;
 using DotNetEnv;
 using AuthService.Data;
+using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -41,6 +42,10 @@ app.MapControllers();
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+    
+    // Apply pending migrations automatically on startup
+    await db.Database.MigrateAsync();
+    
     await DbSeeder.SeedAdminAsync(db);
 }
 

--- a/backend/BookService/Program.cs
+++ b/backend/BookService/Program.cs
@@ -1,6 +1,7 @@
 using BookService.Configurations;
 using DotNetEnv;
 using BookService.Data;
+using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -38,5 +39,12 @@ app.UseAuthorization();
 
 app.UseHttpsRedirection();
 app.MapControllers();
+
+// Apply pending migrations automatically on startup
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<BookDbContext>();
+    await db.Database.MigrateAsync();
+}
 
 app.Run();


### PR DESCRIPTION
- Apply pending EF Core migrations automatically when services start
- AuthService: Run migrations before seeding admin user
- BookService: Run migrations on startup
- Remove EnsureCreatedAsync in favor of proper migrations
- Ensures Azure deployment automatically applies database schema updates